### PR TITLE
Solved built-in PDF viewer JPEG

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,10 @@ RUN apt-get update -qq && \
     curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+RUN docker-php-ext-configure gd \ 
+    --with-freetype=/usr/include/ \ 
+    --with-jpeg=/usr/include/
+
 RUN docker-php-ext-install \
     gd \    
     intl \


### PR DESCRIPTION
The built-in PDF viewer was not working for the Docker version. It looked as it was not loading images because of the `gd` extension. I added the configurations to be able to view JPEG images. See #9 