### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,11 @@ i.e. `-v ${LIBRARY_PATH}:/app/library`.
 6. Connect to [http://localhost:8080](http://localhost:8080) and follow the migration instructions (the library folder to migrate is `/app/library`).
 
 # Update
-Simply stop, remove, and launch your container again. With docker-compose:
+Simply stop, pull the new version, and launch your container again. With docker compose:
 ```
-docker-compose down
-docker-compose up -d
+docker compose down
+docker compose pull
+docker compose up -d
 ```
 
 # Troubleshoot


### PR DESCRIPTION
cleared up updating instructions: used `docker compose` instead of deprecated `docker-compose`, and added a step for `docker compose pull`.